### PR TITLE
attempt at @param modules

### DIFF
--- a/R/setupProject.R
+++ b/R/setupProject.R
@@ -40,9 +40,8 @@ utils::globalVariables(c(
 #'   should be one of: simple name (e.g., `fireSense`) which will be searched for locally
 #'   in the `paths[["modulePath"]]`; or a GitHub repo with branch (`GitHubAccount/Repo@branch` e.g.,
 #'   `"PredictiveEcology/Biomass_core@development"`); or a character vector that identifies
-#'   one or more (not optional file extension) `.R` file(s) (local or GitHub)
-#'   to parse that will produce a character vector assigned to
-#'   the name "modules". If the entire project is a git repository,
+#'   one or more module folders (local or GitHub) (not the module .R script).
+#'   If the entire project is a git repository,
 #'   then it will not try to re-get these modules; instead it will rely on the user
 #'   managing their git status outside of this function.
 #'   See [setup].


### PR DESCRIPTION
Just an attempt to clarify.

I removed the .R ffile "parsing" part, because it suggested one would pass a path to an R file that would be parsed into a module. But this is not working for modules>
On the other hand perhaps passing a local/GH folder path could work (see https://github.com/PredictiveEcology/SpaDES.project/pull/56)?

