### PR TITLE
62 Can no longer pass a `list` to modules

### DIFF
--- a/R/setupProject.R
+++ b/R/setupProject.R
@@ -36,7 +36,7 @@ utils::globalVariables(c(
 #'   Each of these has a sensible default, which will be overridden but any user
 #'   supplied values.
 #'   See [setup].
-#' @param modules a character string of modules to pass to `getModule`. These
+#' @param modules a character vector of modules to pass to `getModule`. These
 #'   should be one of: simple name (e.g., `fireSense`) which will be searched for locally
 #'   in the `paths[["modulePath"]]`; or a GitHub repo with branch (`GitHubAccount/Repo@branch` e.g.,
 #'   `"PredictiveEcology/Biomass_core@development"`); or a character vector that identifies
@@ -1220,6 +1220,11 @@ setupModules <- function(name, paths, modules, inProject, useGit = getOption("Sp
     }
 
     anyfailed <- character()
+
+    if(!is(modules, "character")) {
+      stop("'modules' must be a character vector.")
+    }
+
     modulesOrig <- modules
     modulesOrigPkgName <- extractPkgName(modulesOrig)
     modulesOrigNestedName <- extractModName(modulesOrig)

--- a/tests/testthat/test-setupProject.R
+++ b/tests/testthat/test-setupProject.R
@@ -185,6 +185,7 @@ test_that("test setupProject - load packages using require argument", {
 })
 
 test_that("test setupProject - pass modules as a list", {
+  skip("No longer needed - pass modules as vectors")
   skip_on_cran()
   setupTest()
   ## load packages using `require` argument -- now loads SpaDES.core & reproducible

--- a/tests/testthat/test-setupProject.R
+++ b/tests/testthat/test-setupProject.R
@@ -185,16 +185,27 @@ test_that("test setupProject - load packages using require argument", {
 })
 
 test_that("test setupProject - pass modules as a list", {
-  skip("No longer needed - pass modules as vectors")
   skip_on_cran()
   setupTest()
   ## load packages using `require` argument -- now loads SpaDES.core & reproducible
   mess <- capture_messages({
     out <- setupProject(
       paths = list(projectPath = paste0("testList", .rndstr(1))), # will deduce name of project from projectPath
-      modules = list("PredictiveEcology/Biomass_speciesData@master",
+      modules = c("PredictiveEcology/Biomass_speciesData@master",
                      "PredictiveEcology/Biomass_borealDataPrep@development"))
   })
+
+  expect_true(all(dir(out$paths$modulePath) %in% Require::extractPkgName(out$modules)))
+
+  errs <- capture_error({
+    out <- setupProject(
+      paths = list(projectPath = paste0("testList2", .rndstr(1))), # will deduce name of project from projectPath
+      modules = list("PredictiveEcology/Biomass_speciesData@master",
+                  "PredictiveEcology/Biomass_borealDataPrep@development"))
+  })
+
+  expect_true(length(errs) > 0)
+  expect_true(grepl("'modules' must be a character vector", errs))
 })
 
 

--- a/tests/testthat/test-setupProject.R
+++ b/tests/testthat/test-setupProject.R
@@ -184,8 +184,20 @@ test_that("test setupProject - load packages using require argument", {
 
 })
 
-test_that("test setupProject - studyArea in lonlat", {
+test_that("test setupProject - pass modules as a list", {
+  skip_on_cran()
+  setupTest()
+  ## load packages using `require` argument -- now loads SpaDES.core & reproducible
+  mess <- capture_messages({
+    out <- setupProject(
+      paths = list(projectPath = paste0("testList", .rndstr(1))), # will deduce name of project from projectPath
+      modules = list("PredictiveEcology/Biomass_speciesData@master",
+                     "PredictiveEcology/Biomass_borealDataPrep@development"))
+  })
+})
 
+
+test_that("test setupProject - studyArea in lonlat", {
   skip_on_cran()
   setupTest(c("geodata", "filelock", "reproducible")) # filelock is unnecessary "first time", but errors if run again
   jurs <- "Al|Brit"


### PR DESCRIPTION
https://github.com/PredictiveEcology/SpaDES.project/issues/62


It was decided that `setupProject(..., modules = c())` not `setupProject(..., modules = list(...))` is the right way. 

I've added an internal check for the argument class and made a test that ensures it's being triggered