### PR TITLE
makeDESCRIPTIONproject bug fix: package imports version number mismatch

### DIFF
--- a/R/makeDESCRIPTION.R
+++ b/R/makeDESCRIPTION.R
@@ -116,9 +116,9 @@ makeDESCRIPTION <- function(modules, modulePath, projectPath = ".", singleDESCRI
     if (any(missingSpace))
       inequality[missingSpace] <- gsub("([=><]+)", "\\1 ", inequality[missingSpace])
     hasSC <- grepl("SpaDES.core", imports)
+    imports[hasVersionNumb] <- paste(imports[hasVersionNumb], inequality)
     if (all(!hasSC))
       imports <- c("SpaDES.core", imports)
-    imports[hasVersionNumb] <- paste(imports[hasVersionNumb], inequality)
     d$Imports <- imports
 
     d$Suggests <- c('knitr', 'rmarkdown')


### PR DESCRIPTION
Found an issue with `makeDESCRIPTIONproject` where the DESCRIPTION file is being made with a mismatch between the imported package names and version numbers for `CBM_dataPrep_SK`. This seems to be a simple fix for it.

```
moduleName <- "CBM_dataPrep_SK"
modulePath <- file.path(tempdir(), "modules")
dir.create(modulePath)

getModule(
  "PredictiveEcology/CBM_dataPrep_SK@development@71a953e",
  modulePath = modulePath
)

makeDESCRIPTIONproject(
  modules     = moduleName,
  modulePath  = modulePath,
  projectPath = file.path(modulePath, moduleName)
)

# View package name and version mismatch: terra gets reproducible's version number
file.edit(file.path(modulePath, moduleName, "DESCRIPTION"))
```

Note: this PR doesn't change the version number.