### PR TITLE
module Github path can contain '.' character

### DIFF
--- a/R/setupProject.R
+++ b/R/setupProject.R
@@ -3711,7 +3711,7 @@ extractModName <- function(modules) {
 
 #' @author Ceres Barros
 .extractModName <- function(modules) {
-  if (tools::file_ext(modules) != "") {
+  if (toupper(tools::file_ext(modules)) == "R") {
     stop("Expecting local or GitHub path to the module *folder* not .R file.")
   }
 


### PR DESCRIPTION
Fix for `setupProject` failing when the module Github path contains a reference to a release containing the '.' character.

Without this, the following fails with `Error in (function (modules)  : Expecting local or GitHub path to the module *folder* not .R file.`:

```
SpaDES.project::setupProject(
  modules = "PredictiveEcology/CBM_defaults@v1.0.0",
  paths   = list(projectPath = tempfile())
)
```