### PR TITLE
test: guard drive_auth on file.exists(GOOGLEDRIVE_AUTH)

### DIFF
--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -41,8 +41,10 @@ setupTest <- function(pkgs, envir = parent.frame(), name = .rndstr(1), first = F
 
   if (isNamespaceLoaded("googledrive"))
     if ((!googledrive::drive_has_token())) {
-      if (nzchar(Sys.getenv("GOOGLEDRIVE_AUTH"))) {
-        googledrive::drive_auth(path = Sys.getenv("GOOGLEDRIVE_AUTH"))
+      gauthEnv <- Sys.getenv("GOOGLEDRIVE_AUTH")
+      if (nzchar(gauthEnv)) {
+        if (file.exists(gauthEnv))
+          googledrive::drive_auth(path = gauthEnv)
       }
     }
 


### PR DESCRIPTION
## Summary
- Add `file.exists()` guard around `drive_auth(path = Sys.getenv("GOOGLEDRIVE_AUTH"))` in `tests/testthat/helpers.R::setupTest()`
- Mirrors the pattern used in `PredictiveEcology/reproducible`'s `tests/testthat/setup.R`

## Why
The unguarded `drive_auth(path = ...)` call raises a hard error in `setupTest()` whenever the `GOOGLEDRIVE_AUTH` env var holds a string that is not a usable path on disk — e.g. when CI injects raw JSON content as a secret, or when a contributor has the var unset. The error fires before any test body runs, so every test in the file fails. This is currently the cause of all 11 failures in the upstream `reproducible` test-downstream workflow.

With the guard, auth is silently skipped when the env var is not a usable path; tests that do not actually need a Drive token (e.g. the GitHub-only `setupProject` tests) then proceed normally.

## Test plan
- [ ] CI runs green for the (currently broken) `setupProject` tests on `test-downstream`