### PR TITLE
fix(#78): remove SpaDES.config dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ URL:
     https://spades-project.predictiveecology.org/,
     https://github.com/PredictiveEcology/SpaDES.project
 Date: 2026-04-30
-Version: 1.0.1.9296
+Version: 1.0.1.9297
 Authors@R: c(
     person("Eliot J B", "McIntire", email = "eliot.mcintire@nrcan-rncan.gc.ca",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6914-8316")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ URL:
     https://spades-project.predictiveecology.org/,
     https://github.com/PredictiveEcology/SpaDES.project
 Date: 2026-04-30
-Version: 1.0.1.9295
+Version: 1.0.1.9296
 Authors@R: c(
     person("Eliot J B", "McIntire", email = "eliot.mcintire@nrcan-rncan.gc.ca",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6914-8316")),
@@ -66,7 +66,6 @@ Suggests:
     reproducible,
     rmarkdown,
     sf,
-    SpaDES.config,
     SpaDES.core,
     terra,
     testthat (>= 3.0.0),
@@ -75,8 +74,7 @@ Suggests:
     visNetwork,
     waldo,
     withr
-Remotes: 
-    PredictiveEcology/SpaDES.config@development,
+Remotes:
     PredictiveEcology/SpaDES.core@development
 Encoding: UTF-8
 Language: en-CA

--- a/NEWS.md
+++ b/NEWS.md
@@ -79,6 +79,10 @@ version 1.0.1
   queue-less micro-runner. The conceptual differences are documented
   in the "Experiments" chapter of the SpaDES4Modellers book.
 
+## Removed
+
+* Drop `SpaDES.config` dependency (Suggests + Remotes); resolves the circular dep flagged in #78. The `config` arg to `setupProject()` was never wired up and now stops with a clearer message.
+
 ## Bug fixes
 
 * `tmuxRunNextWorker()` no longer calls `reproducible::checkPath()`; uses `dir.create()` so workers run under `_R_CHECK_DEPENDS_ONLY_=true` (where Suggests are absent).

--- a/R/setupProject.R
+++ b/R/setupProject.R
@@ -56,8 +56,8 @@ utils::globalVariables(c(
 #' @param times Optional. This will be returned if supplied; if supplied, the values
 #'   can be used in e.g., `params`, e.g., `params = list(mod = list(startTime = times$start))`.
 #'   See help for `SpaDES.core::simInit`.
-#' @param config Still experimental linkage to the `SpaDES.config` package. Currently
-#'   not working.
+#' @param config Reserved for future use. Currently unimplemented; supplying
+#'   a value triggers an error.
 #' @param packages Optional. A vector of packages that must exist in the `libPaths`.
 #'   This will be passed to `Require::Install`, i.e., these will be installed, but
 #'   not attached to the search path. See also the `require` argument. To force skip
@@ -668,22 +668,11 @@ setupProject <- function(name, paths, modules, packages,
       #               libPaths = paths[["packagePath"]], envir = envirCur, verbose = verbose)
 
       if (!missing(config)) {
-        # messageVerbose("config is supplied; using `SpaDES.config` package internals", verbose = verbose)
-        # if (!requireNamespace("SpaDES.config", quietly = TRUE)) {
-        #   Require::Install("PredictiveEcology/SpaDES.config@development")
-        # }
-        messageWarnStop("config is not yet setup to run with SpaDES.project")
-        # if (FALSE)
-        #   out <- do.call(SpaDES.config::useConfig, append(
-        #     list(projectName = config,
-        #          projectPath = paths[["projectPath"]], paths = paths),
-        #     localVars))
-
+        messageWarnStop("`config` is not yet supported by setupProject().")
       }
       if (failedBCMissingPackage %in% FALSE)
         break
     }
-    # TODO from here to out <-  should be brought into the "else" block when `SpaDES.config is worked on`
     remainingArgs <- origArgOrder[!argsAreInFormals]
     remainingArgs <- remainingArgs[nzchar(remainingArgs)]
     # if (missing(paramsSUB))

--- a/man/setupProject.Rd
+++ b/man/setupProject.Rd
@@ -101,8 +101,8 @@ packages, prefix the function call with the package e.g., \code{terra::rast}. Wh
 using \code{setupProject}, the \code{functions} argument is evaluated after \code{paths}, so
 it cannot be used to define functions that help specify \code{paths}.}
 
-\item{config}{Still experimental linkage to the \code{SpaDES.config} package. Currently
-not working.}
+\item{config}{Reserved for future use. Currently unimplemented; supplying
+a value triggers an error.}
 
 \item{require}{Optional. A character vector of packages to install \emph{and} attach
 (with \code{Require::Require}). These will be installed and attached at the start


### PR DESCRIPTION
## Summary

Removes the `SpaDES.config` dependency from `Suggests` and `Remotes`. `SpaDES.config` lists `SpaDES.project` as a dependency, so listing it back here creates a circular dep that breaks reverse-dependency checks for `SpaDES.project`.

The `config` argument of `setupProject()` was the only call site, and the live code already errored with `"config is not yet setup to run with SpaDES.project"`. The `SpaDES.config::useConfig()` and `Require::Install("...SpaDES.config@development")` lines were already commented out.

This PR:
- drops `SpaDES.config` from `Suggests` and from `Remotes`
- removes the dead `# SpaDES.config::useConfig(...)` comment block
- sharpens the stop message for `setupProject(config = ...)`
- updates the `@param config` docs (and the regenerated Rd) to no longer mention `SpaDES.config`

The `config` formal is preserved so existing callers still parse.

Closes #78.

Targeting `working/combined-prs` so it lands ahead of #89 per request.

## Test plan

- [ ] `R CMD check` clean (no Suggests reference to `SpaDES.config`)
- [ ] `devtools::test()` passes locally
- [ ] `setupProject(config = "x")` still emits a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)