### PR TITLE
feat(setupPackages): dput() of package vector at verbose >= 3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ URL:
     https://spades-project.predictiveecology.org/,
     https://github.com/PredictiveEcology/SpaDES.project
 Date: 2026-05-14
-Version: 1.0.1.9309
+Version: 1.0.1.9310
 Authors@R: c(
     person("Eliot J B", "McIntire", email = "eliot.mcintire@nrcan-rncan.gc.ca",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6914-8316")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ URL:
     https://spades-project.predictiveecology.org/,
     https://github.com/PredictiveEcology/SpaDES.project
 Date: 2026-05-14
-Version: 1.0.1.9308
+Version: 1.0.1.9309
 Authors@R: c(
     person("Eliot J B", "McIntire", email = "eliot.mcintire@nrcan-rncan.gc.ca",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6914-8316")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@ version 1.0.1
 
 ## Enhancements
 
+* `setupProject()` / `setupPackages()` print the `dput()` of the exact package vector passed to `Require::Require` at `verbose >= 3`.
 * Fresh claims scrub stale `finished_at` / `DEoptimElapsedTime` / `heartbeat_*` / `iterationsTotal` / `interrupted_at` (both backends).
 * `DONE` clears `claimed_by`; `process_id` and `machine_name` are preserved as a historical record.
 * `.gs_demote_after_kill()` clears every per-run metadata column, matching `tmuxRefreshQueueStatus()`.

--- a/R/setupProject.R
+++ b/R/setupProject.R
@@ -423,6 +423,11 @@ NULL
 #' @importFrom stats na.omit setNames
 #' @inheritParams Require::Require
 #' @inheritParams Require::setLibPaths
+#' @section Verbosity:
+#' `verbose` is passed through to the inner `setup*` helpers. Notably, `verbose >= 2`
+#' prints the modules' `reqdPkgs` grouped by module, and `verbose >= 3` additionally
+#' prints the `dput()` of the exact package vector passed to `Require::Require` (see
+#' [setupPackages()]).
 #' @seealso
 #' Inner `setup*` helpers (each has its own help page; see [setup_family]
 #' for a one-page overview):
@@ -1924,6 +1929,11 @@ setupModules <- function(name, paths, modules, inProject, useGit = getOption("Sp
 #' @inheritParams setupPaths
 #' @param modulePackages A named list, where names are the module names, and the elements
 #'   of the list are packages in a form that `Require::Require` accepts.
+#' @param verbose Numeric or logical indicating how verbose the function should be.
+#'   At `verbose >= 2`, the combined `reqdPkgs` are printed grouped by module. At
+#'   `verbose >= 3`, additionally the `dput()` of the exact package vector passed to
+#'   `Require::Require` is printed, which can be copy-pasted to reproduce the install
+#'   call. If not supplied, defaults to `getOption("Require.verbose")`.
 #'
 #' @return
 #' `setupPackages` is run for its side effects, i.e., installing packages to
@@ -2024,6 +2034,12 @@ setupPackages <- function(packages, modulePackages = list(), require = list(), p
         #   }
         # }
         # needToAssess <- packagesToTry
+
+        if (verbose >= 3) {
+          messageVerbose("Packages passed to Require::Require:", verbose = verbose, verboseLevel = 3)
+          messageVerbose(paste(capture.output(dput(needToAssess)), collapse = "\n"),
+                         verbose = verbose, verboseLevel = 3)
+        }
 
         if (sum(nzchar(needToAssess))) {
           withCallingHandlers(

--- a/man/setupPackages.Rd
+++ b/man/setupPackages.Rd
@@ -57,11 +57,11 @@ to set this}
 which represents the case where the inner \verb{setup*} functions are called inside
 \code{setupProject}, which was called by a user.}
 
-\item{verbose}{Numeric or logical indicating how verbose should the function
-be. If -1 or -2, then as little verbosity as possible. If 0 or FALSE,
-then minimal outputs; if \code{1} or TRUE, more outputs; \code{2} even more. NOTE: in
-\code{Require} function, when \code{verbose >= 2}, also returns details as if
-\code{returnDetails = TRUE} (for backwards compatibility).}
+\item{verbose}{Numeric or logical indicating how verbose the function should be.
+At \code{verbose >= 2}, the combined \code{reqdPkgs} are printed grouped by module. At
+\code{verbose >= 3}, additionally the \code{dput()} of the exact package vector passed to
+\code{Require::Require} is printed, which can be copy-pasted to reproduce the install
+call. If not supplied, defaults to \code{getOption("Require.verbose")}.}
 
 \item{dots}{Any other named objects passed as a list a user might want for other elements.}
 

--- a/man/setupProject.Rd
+++ b/man/setupProject.Rd
@@ -438,6 +438,14 @@ out <- setupProject(.mode = .mode,
 }
 }
 
+\section{Verbosity}{
+
+\code{verbose} is passed through to the inner \verb{setup*} helpers. Notably, \code{verbose >= 2}
+prints the modules' \code{reqdPkgs} grouped by module, and \code{verbose >= 3} additionally
+prints the \code{dput()} of the exact package vector passed to \code{Require::Require} (see
+\code{\link[=setupPackages]{setupPackages()}}).
+}
+
 \examples{
 ## For more examples:
 vignette("i-getting-started", package = "SpaDES.project")


### PR DESCRIPTION
## Summary
At `verbose >= 3`, `setupPackages` now prints the `dput()` of the exact package vector (`needToAssess`) passed to `Require::Require`, just before the call. This makes the install set copy-paste reproducible.

- `verbose >= 2` (unchanged): prints `reqdPkgs` grouped by module.
- `verbose >= 3` (new): additionally prints the `dput()` of the package vector handed to `Require::Require`.

Documentation for the new level added to `setupPackages` (`@param verbose`) and a `@section Verbosity` note in `setupProject`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)