### PR TITLE
Pilot: use shared reusable CI workflows (pkgdown, R-CMD-check, test-coverage)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   R-CMD-check:
     if: "!contains(github.event.commits[0].message, '[skip-ci]')"
-    uses: PredictiveEcology/actions/.github/workflows/R-CMD-check.yaml@reusable-workflows
+    uses: PredictiveEcology/actions/.github/workflows/R-CMD-check.yaml@main
     secrets: inherit
     with:
       extra-packages: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,159 +1,27 @@
+# Thin caller — shared logic lives in PredictiveEcology/actions (reusable workflow).
 on:
   push:
-    branches:
-      - main
-      - master
-      - development
-      - transition
+    branches: [main, master, development, transition]
   pull_request:
-    branches:
-      - main
-      - master
-      - development
-      - transition
+    branches: [main, master, development, transition]
 
 name: R-CMD-check
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
 jobs:
   R-CMD-check:
     if: "!contains(github.event.commits[0].message, '[skip-ci]')"
-    runs-on: ${{ matrix.config.os }}
-
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
-
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - {os: macOS-latest,   nosuggests: false, r: 'release'}
-          - {os: windows-latest, nosuggests: false, r: 'devel'}
-          - {os: windows-latest, nosuggests: false, r: 'release'}
-          - {os: windows-latest, nosuggests: false, r: 'oldrel-1'}
-          - {os: ubuntu-latest,   nosuggests: false, r: 'devel'}
-          - {os: ubuntu-latest,   nosuggests: false, r: 'release'}
-          - {os: ubuntu-latest,   nosuggests: true,  r: 'release'}
-          - {os: ubuntu-latest,   nosuggests: false, r: 'oldrel-1'}
-
-    env:
-      _R_CHECK_DEPENDS_ONLY_: ${{ matrix.config.nosuggests }}
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      GOOGLEDRIVE_AUTH: ${{ secrets.ELIOT_GOOGLE_AUTHENTICATION }}
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-
-    steps:
-      - uses: actions/checkout@v4
-
-      # setup-pandoc occasionally fails with HTTP 5xx (CDN blip).
-      # Three attempts with continue-on-error ride out transient failures.
-      - id: pandoc1
-        continue-on-error: true
-        uses: r-lib/actions/setup-pandoc@v2
-      - if: steps.pandoc1.outcome == 'failure'
-        id: pandoc2
-        continue-on-error: true
-        uses: r-lib/actions/setup-pandoc@v2
-      - if: steps.pandoc1.outcome == 'failure' && steps.pandoc2.outcome == 'failure'
-        uses: r-lib/actions/setup-pandoc@v2
-
-      # Install geospatial system deps WITHOUT the ubuntugis-unstable PPA.
-      # That PPA installs libgdal37 (GDAL 3.11.x), but Posit's noble binary cache
-      # builds quickPlot/sf/terra against the Ubuntu-default libgdal34 -- the ABI
-      # mismatch surfaces as `libgdal.so.34: cannot open shared object file` when
-      # quickPlot loads (and fails the whole check via SpaDES.core lazy-load).
-      - name: Install geospatial system dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y libudunits2-dev libgdal-dev libgeos-dev libproj-dev libsqlite3-dev
-        shell: bash
-      - name: Install geospatial system dependencies (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          brew install pkg-config
-          brew install gdal
-        shell: zsh {0}
-
-      # Homebrew's gdal/proj install does not always leave proj.db on PROJ's
-      # default search path. Without it, terra::project()/terra::crs() emit
-      # "PROJ: proj_identify: Cannot find proj.db (GDAL error 1)" and any
-      # reprojection-touching test fails. Point PROJ at Homebrew's data dir.
-      - name: Configure PROJ data path (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          PROJ_PREFIX="$(brew --prefix proj 2>/dev/null || true)"
-          PROJ_DATA="$PROJ_PREFIX/share/proj"
-          if [ ! -d "$PROJ_DATA" ]; then PROJ_DATA="/opt/homebrew/share/proj"; fi
-          if [ ! -d "$PROJ_DATA" ]; then PROJ_DATA="/usr/local/share/proj"; fi
-          echo "PROJ_DATA=$PROJ_DATA" >> "$GITHUB_ENV"
-          echo "PROJ_LIB=$PROJ_DATA"  >> "$GITHUB_ENV"
-          echo "Using PROJ_DATA=$PROJ_DATA"
-          ls -1 "$PROJ_DATA" | head -5 || true
-
-      # Homebrew's gdal/proj install does not always leave proj.db on PROJ's
-      # default search path. Without it, terra::project()/terra::crs() emit
-      # "PROJ: proj_identify: Cannot find proj.db (GDAL error 1)" and any
-      # reprojection-touching test fails. Point PROJ at Homebrew's data dir.
-      - name: Configure PROJ data path (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          PROJ_PREFIX="$(brew --prefix proj 2>/dev/null || true)"
-          PROJ_DATA="$PROJ_PREFIX/share/proj"
-          if [ ! -d "$PROJ_DATA" ]; then PROJ_DATA="/opt/homebrew/share/proj"; fi
-          if [ ! -d "$PROJ_DATA" ]; then PROJ_DATA="/usr/local/share/proj"; fi
-          echo "PROJ_DATA=$PROJ_DATA" >> "$GITHUB_ENV"
-          echo "PROJ_LIB=$PROJ_DATA"  >> "$GITHUB_ENV"
-          echo "Using PROJ_DATA=$PROJ_DATA"
-          ls -1 "$PROJ_DATA" | head -5 || true
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          extra-repositories: 'https://PredictiveEcology.r-universe.dev/'
-          Ncpus: 2
-          r-version: ${{ matrix.config.r }}
-          # Posit Public Package Manager — pre-built Windows + macOS binaries
-          # served from a CDN. More reliable than CRAN mirrors for binaries.
-          use-public-rspm: true
-
-      - id: deps
-        continue-on-error: true
-        uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          # Pin pak to its stable channel; devel occasionally regresses.
-          pak-version: stable
-          extra-packages: |
-            any::rcmdcheck
-            any::rematch2
-            fastshp=?ignore
-            NLMR=?ignore
-            PredictiveEcology/Require@development
-
-      # Fallback when setup-r-dependencies fails (most often a transient
-      # binary-fetch failure under pak). Up to 3 attempts with 60s backoff.
-      # `nick-fields/retry@v3` does not accept `shell: Rscript {0}`, so we
-      # invoke Rscript -e from bash.
-      - name: Install R deps (retry fallback)
-        if: steps.deps.outcome == 'failure'
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 30
-          max_attempts: 3
-          retry_wait_seconds: 60
-          retry_on: error
-          shell: bash
-          command: |
-            Rscript -e 'install.packages("pak", repos = "https://r-lib.github.io/p/pak/stable/")' \
-                    -e 'pak::local_install_dev_deps(ask = FALSE, dependencies = TRUE)' \
-                    -e 'pak::pkg_install(c("any::rcmdcheck", "any::rematch2", "PredictiveEcology/Require@development"), ask = FALSE)'
-
-      - name: Install additional package dependencies
-        run: |
-          pak::pkg_install("ropensci/NLMR")
-          tryCatch(remotes::install_github("s-u/fastshp"), error = function(e) message("fastshp install failed (likely compilation issue): ", conditionMessage(e)))
-        shell: Rscript {0}
-
-      - uses: r-lib/actions/check-r-package@v2
-        with:
-          upload-snapshots: true
+    uses: PredictiveEcology/actions/.github/workflows/R-CMD-check.yaml@reusable-workflows
+    secrets: inherit
+    with:
+      extra-packages: |
+        any::rematch2
+        fastshp=?ignore
+        NLMR=?ignore
+        PredictiveEcology/Require@development
+      post-install: |
+        pak::pkg_install("ropensci/NLMR")
+        tryCatch(remotes::install_github("s-u/fastshp"), error = function(e) message("fastshp install failed (likely compilation issue): ", conditionMessage(e)))

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,5 +1,4 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+# Thin caller — shared logic lives in PredictiveEcology/actions (reusable workflow).
 on:
   push:
     branches: [main, master]
@@ -13,51 +12,16 @@ name: pkgdown
 
 jobs:
   pkgdown:
-    runs-on: ubuntu-latest
-    # Only restrict concurrency for non-PR jobs
-    concurrency:
-      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          extra-repositories: 'https://PredictiveEcology.r-universe.dev/'
-          Ncpus: 2
-          use-public-rspm: false
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: |
-            any::pkgdown
-            local::.
-            fastshp=?ignore
-            NLMR=?ignore
-            PredictiveEcology/Require@development
-            PredictiveEcology/reproducible@development
-            PredictiveEcology/SpaDES.tools@development
-          needs: website
-
-      - name: Install additional package dependencies
-        run: |
-          pak::pkg_install("ropensci/NLMR")
-          tryCatch(remotes::install_github("s-u/fastshp"), error = function(e) message("fastshp install failed (likely compilation issue): ", conditionMessage(e)))
-        shell: Rscript {0}
-
-      - name: Build site
-        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
-        shell: Rscript {0}
-
-      - name: Deploy to GitHub pages 🚀
-        if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          clean: false
-          branch: gh-pages
-          folder: docs
+    uses: PredictiveEcology/actions/.github/workflows/pkgdown.yaml@reusable-workflows
+    secrets: inherit
+    with:
+      # Only pin Require@development (matches R-CMD-check / test-coverage).
+      # Do NOT pin reproducible/SpaDES.tools @development: SpaDES.core@development
+      # requires reproducible@prepInputsLog, which conflicts with @development.
+      extra-packages: |
+        fastshp=?ignore
+        NLMR=?ignore
+        PredictiveEcology/Require@development
+      post-install: |
+        pak::pkg_install("ropensci/NLMR")
+        tryCatch(remotes::install_github("s-u/fastshp"), error = function(e) message("fastshp install failed (likely compilation issue): ", conditionMessage(e)))

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -12,7 +12,7 @@ name: pkgdown
 
 jobs:
   pkgdown:
-    uses: PredictiveEcology/actions/.github/workflows/pkgdown.yaml@reusable-workflows
+    uses: PredictiveEcology/actions/.github/workflows/pkgdown.yaml@main
     secrets: inherit
     with:
       # Only pin Require@development (matches R-CMD-check / test-coverage).

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,56 +1,26 @@
+# Thin caller — shared logic lives in PredictiveEcology/actions (reusable workflow).
 on:
   push:
-    branches:
-      - main
-      - development
+    branches: [main, development]
   pull_request:
-    branches:
-      - main
-      - development
+    branches: [main, development]
 
 name: test-coverage
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
 jobs:
   test-coverage:
     if: "!contains(github.event.commits[0].message, '[skip-ci]')"
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      GOOGLEDRIVE_AUTH: ${{ secrets.GOOGLEDRIVE_AUTH }}
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      USING_COVR: true
-      NOT_CRAN: "true"
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          Ncpus: 2
-          use-public-rspm: false
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: |
-            any::covr
-            fastshp=?ignore
-            NLMR=?ignore
-            PredictiveEcology/Require@development
-
-      - name: Install additional package dependencies
-        run: |
-          pak::pkg_install("ropensci/NLMR")
-          tryCatch(pak::pkg_install("s-u/fastshp"), error = function(e) message("fastshp install failed (likely compilation issue): ", conditionMessage(e)))
-        shell: Rscript {0}
-
-      - name: Test coverage
-        run: covr::codecov()
-        shell: Rscript {0}
-
+    uses: PredictiveEcology/actions/.github/workflows/test-coverage.yaml@reusable-workflows
+    secrets: inherit
+    with:
+      extra-packages: |
+        fastshp=?ignore
+        NLMR=?ignore
+        PredictiveEcology/Require@development
+      post-install: |
+        pak::pkg_install("ropensci/NLMR")
+        tryCatch(pak::pkg_install("s-u/fastshp"), error = function(e) message("fastshp install failed (likely compilation issue): ", conditionMessage(e)))

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   test-coverage:
     if: "!contains(github.event.commits[0].message, '[skip-ci]')"
-    uses: PredictiveEcology/actions/.github/workflows/test-coverage.yaml@reusable-workflows
+    uses: PredictiveEcology/actions/.github/workflows/test-coverage.yaml@main
     secrets: inherit
     with:
       extra-packages: |

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ URL:
     https://spades-project.predictiveecology.org/,
     https://github.com/PredictiveEcology/SpaDES.project
 Date: 2026-05-22
-Version: 1.0.1.9341
+Version: 1.0.1.9342
 Authors@R: c(
     person("Eliot J B", "McIntire", email = "eliot.mcintire@nrcan-rncan.gc.ca",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6914-8316")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ URL:
     https://spades-project.predictiveecology.org/,
     https://github.com/PredictiveEcology/SpaDES.project
 Date: 2026-05-22
-Version: 1.0.1.9337
+Version: 1.0.1.9338
 Authors@R: c(
     person("Eliot J B", "McIntire", email = "eliot.mcintire@nrcan-rncan.gc.ca",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6914-8316")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ URL:
     https://spades-project.predictiveecology.org/,
     https://github.com/PredictiveEcology/SpaDES.project
 Date: 2026-05-22
-Version: 1.0.1.9339
+Version: 1.0.1.9340
 Authors@R: c(
     person("Eliot J B", "McIntire", email = "eliot.mcintire@nrcan-rncan.gc.ca",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6914-8316")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ URL:
     https://spades-project.predictiveecology.org/,
     https://github.com/PredictiveEcology/SpaDES.project
 Date: 2026-05-22
-Version: 1.0.1.9340
+Version: 1.0.1.9341
 Authors@R: c(
     person("Eliot J B", "McIntire", email = "eliot.mcintire@nrcan-rncan.gc.ca",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6914-8316")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ URL:
     https://spades-project.predictiveecology.org/,
     https://github.com/PredictiveEcology/SpaDES.project
 Date: 2026-05-22
-Version: 1.0.1.9338
+Version: 1.0.1.9339
 Authors@R: c(
     person("Eliot J B", "McIntire", email = "eliot.mcintire@nrcan-rncan.gc.ca",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6914-8316")),


### PR DESCRIPTION
Pilots the centralized CI from PredictiveEcology/actions#3 on SpaDES.project only.

- Replaces the 3 standalone workflows with thin callers of `PredictiveEcology/actions/.github/workflows/*.yaml@reusable-workflows`.
- Per-repo bits (`extra-packages`, `post-install`) are passed as inputs; secrets via `secrets: inherit`.
- **Also fixes the pkgdown dependency conflict**: dropped the `reproducible@development` / `SpaDES.tools@development` pins (SpaDES.core@development requires reproducible@prepInputsLog → conflict). Now matches the working R-CMD-check / test-coverage pin set.

Opening this PR runs all three against the reusable workflows; merging deploys the pkgdown site. Once green, retag actions (move `v0`) and flip the `@reusable-workflows` refs to the tag, then roll the stubs to other repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)