### PR TITLE
errorsWithDiagnostics

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -85,10 +85,11 @@ BugReports: https://github.com/PredictiveEcology/SpaDES.project/issues
 ByteCompile: yes
 Roxygen: list(markdown = TRUE)
 Config/testthat/edition: 3
-Collate: 
+Collate:
     'SpaDES.projectOptions.R'
     'simLists-class.R'
     'as.data.table-simLists.R'
+    'diagnostics.R'
     'download.R'
     'environment.R'
     'experiment-family.R'

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -82,7 +82,7 @@ setupDiagRecord <- function(context = NA_character_, expr, error = NULL,
 
 ## Truncate a one-line string for the summary header.
 .diagTrunc <- function(s, n = 120L) {
-  if (!nzchar(s) || nchar(s) <= n) s else paste0(substr(s, 1L, n - 1L), "…")
+  if (!nzchar(s) || nchar(s) <= n) s else paste0(substr(s, 1L, n - 3L), "...")
 }
 
 ## Render and optionally escalate the diagnostic scope.

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1,0 +1,161 @@
+## setupProject diagnostics ---------------------------------------------------
+##
+## setupProject's resolution layer (evalSUB + evalListElems and the fallbacks
+## they call) is intentionally tolerant: an entry that fails in `envir` is
+## retried in `envir2`, then against sys.frames(), then against a synthetic env;
+## an entry that fails as a whole `list(...)`/block is retried element-wise. The
+## design is right -- a missing optional file or an undefined name shouldn't
+## abort the whole setup -- but the cost is that a *real* failure (e.g.
+## pkgload::load_all() failing because a package's R/ file has a parse error)
+## gets demoted to a verbose-gated `message()` and the run continues with a
+## half-loaded or stale namespace.
+##
+## This module adds a per-`setupProject()` diagnostic scope:
+##   - `setupDiagOpen()` pushes a scope onto a stack
+##   - `evalSUB` / `evalListElems` push records onto the current scope, BUT
+##     only after they know the *final* outcome (so an expected first-try
+##     failure recovered by a fallback is not reported as an error)
+##   - `setupDiagReport()` summarises records at the end of setupProject
+##   - `options(SpaDES.project.strict = TRUE)` escalates the summary to a stop
+##
+## Recording the final outcome (rather than every internal try) is the trick
+## that avoids drowning the report in expected-fallback noise; the report still
+## dedupes by deparsed expression in case the same expression bubbles through
+## both evalSUB and evalListElems.
+
+.spadesProjectDiag <- new.env(parent = emptyenv())
+.spadesProjectDiag$stack <- list()
+
+## Push a fresh diagnostic scope; returns it (callers don't usually need it).
+setupDiagOpen <- function() {
+  scope <- new.env(parent = emptyenv())
+  scope$attempts <- list()
+  s <- .spadesProjectDiag$stack
+  s[[length(s) + 1L]] <- scope
+  .spadesProjectDiag$stack <- s
+  scope
+}
+
+## Pop the current scope. Safe to call when none is open.
+setupDiagClose <- function() {
+  s <- .spadesProjectDiag$stack
+  if (length(s)) .spadesProjectDiag$stack <- s[-length(s)]
+  invisible()
+}
+
+## The active scope, or NULL if no setupProject call is on the stack.
+setupDiagCurrent <- function() {
+  s <- .spadesProjectDiag$stack
+  if (length(s)) s[[length(s)]] else NULL
+}
+
+## Record one resolved attempt. Callers must only call this AFTER the final
+## outcome of their try-ladder is known -- so `recovered = TRUE` actually means
+## "the eval eventually succeeded" and `recovered = FALSE` means "all paths
+## failed; the value handed back was the unevaluated input."
+##
+## - `context`   short tag (`"sideEffects"`, `"modules"`, ...); use NA if unknown
+## - `expr`      the original (unevaluated) expression the caller was resolving
+## - `error`     try-error or condition collected from the failing path; NULL if
+##               the only thing of note was a warning
+## - `warnings`  warning messages collected via withCallingHandlers
+## - `recovered` TRUE if a fallback path produced a usable value
+setupDiagRecord <- function(context = NA_character_, expr, error = NULL,
+                            warnings = NULL, recovered = FALSE) {
+  scope <- setupDiagCurrent()
+  if (is.null(scope)) return(invisible())
+  if (is.null(error) && !length(warnings)) return(invisible())  # nothing to report
+
+  exprStr <- tryCatch(paste(deparse(expr, width.cutoff = 500L), collapse = " "),
+                      error = function(e) "<unparseable>")
+  if (!is.null(error)) error <- trimws(as.character(error))
+
+  scope$attempts[[length(scope$attempts) + 1L]] <- list(
+    context = if (is.null(context)) NA_character_ else context,
+    expr = exprStr,
+    error = error,
+    warnings = if (length(warnings)) as.character(warnings) else NULL,
+    recovered = isTRUE(recovered)
+  )
+  invisible()
+}
+
+## Truncate a one-line string for the summary header.
+.diagTrunc <- function(s, n = 120L) {
+  if (!nzchar(s) || nchar(s) <= n) s else paste0(substr(s, 1L, n - 1L), "…")
+}
+
+## Render and optionally escalate the diagnostic scope.
+##
+## Output goes via `message()` so it lands on stderr and is not swallowed by
+## suppressMessages() at the user's call-site by accident; strict mode raises
+## a final error after the summary so the user keeps the full diagnostic and
+## the stop trace.
+setupDiagReport <- function(scope = setupDiagCurrent(),
+                            strict = getOption("SpaDES.project.strict", FALSE),
+                            verbose = getOption("Require.verbose", 1L)) {
+  if (is.null(scope)) return(invisible())
+  atts <- scope$attempts
+  if (!length(atts)) return(invisible())
+
+  ## dedupe by (context, exprStr, error) so the same swallow seen at multiple
+  ## layers (e.g. evalSUB's block-level retry + evalListElems' per-statement
+  ## retry) collapses to one entry
+  keys <- vapply(atts, function(r)
+    paste(r$context, r$expr,
+          if (is.null(r$error)) "" else paste(r$error, collapse = "\n"),
+          sep = ""), character(1))
+  atts <- atts[!duplicated(keys)]
+
+  hard <- Filter(function(r) length(r$error) && !r$recovered, atts)
+  soft <- Filter(function(r) length(r$error) &&  r$recovered, atts)
+  wOnly <- Filter(function(r) is.null(r$error) && length(r$warnings), atts)
+
+  if (!length(hard) && !length(soft) && !length(wOnly)) return(invisible())
+
+  header <- sprintf(
+    "setupProject diagnostics: %d unrecovered, %d recovered, %d warning-only",
+    length(hard), length(soft), length(wOnly))
+  message(header)
+
+  pretty <- function(rec, tag) {
+    ctx <- if (is.na(rec$context) || !nzchar(rec$context)) "" else paste0(" [", rec$context, "]")
+    message(sprintf("  - %s%s: %s", tag, ctx, .diagTrunc(rec$expr)))
+    if (length(rec$error))
+      for (line in unlist(strsplit(rec$error, "\n", fixed = TRUE)))
+        if (nzchar(line)) message("      ", line)
+    if (length(rec$warnings))
+      for (w in rec$warnings)
+        for (line in unlist(strsplit(w, "\n", fixed = TRUE)))
+          if (nzchar(line)) message("      warning: ", line)
+  }
+  for (r in hard)  pretty(r, "ERROR")
+  for (r in soft)  pretty(r, "recovered")
+  for (r in wOnly) pretty(r, "warning")
+
+  if (length(hard))
+    message("  (run setupProject(...) with options(SpaDES.project.strict = TRUE) to stop on unrecovered errors)")
+  if (isTRUE(strict) && length(hard)) {
+    stop(sprintf("setupProject: %d unrecovered error(s) (see diagnostics above)",
+                 length(hard)),
+         call. = FALSE)
+  }
+  invisible()
+}
+
+## Run `expr` with a fresh diagnostic scope, then report. Caller-friendly
+## wrapper used by setupProject().
+withSetupDiagnostics <- function(expr,
+                                 strict = getOption("SpaDES.project.strict", FALSE),
+                                 verbose = getOption("Require.verbose", 1L)) {
+  scope <- setupDiagOpen()
+  on.exit({
+    tryCatch(setupDiagReport(scope, strict = strict, verbose = verbose),
+             error = function(e) {
+               setupDiagClose()
+               stop(e)
+             })
+    setupDiagClose()
+  }, add = TRUE)
+  force(expr)
+}

--- a/R/setupProject.R
+++ b/R/setupProject.R
@@ -498,6 +498,19 @@ setupProject <- function(name, paths, modules, packages,
                             reposNow[setdiff(names(reposNow), "CRAN")]))
   }
 
+  ## open a diagnostic scope for this setupProject invocation; the
+  ## evalSUB / evalListElems instrumentation will push records into it, and
+  ## `setupDiagReport()` (registered on.exit just below) renders a summary at
+  ## the end. See R/diagnostics.R. Strict mode escalates to a final stop().
+  .spadesProjectDiagScope <- setupDiagOpen()
+  on.exit({
+    tryCatch(setupDiagReport(.spadesProjectDiagScope,
+                             strict = getOption("SpaDES.project.strict", FALSE),
+                             verbose = verbose),
+             error = function(e) { setupDiagClose(); stop(e) })
+    setupDiagClose()
+  }, add = TRUE)
+
   withCallingHandlers({
     makeUpdateRprofileSticky(updateRprofile)
 
@@ -1497,7 +1510,12 @@ evalListElems <- function(l, envir, verbose = getOption("Require.verbose", 1L)) 
                       warning = function(w) {
                         warns <<- w
                       })
+  ## stash the original so we can tell at the end whether the element-wise
+  ## fallback below actually recovered (changed `l`) or just gave up
+  setupDiagOrigL <- l
+  setupDiagInitialError <- NULL
   if (is(l2, "try-error")) {
+    setupDiagInitialError <- l2
     mess <- gsub("Error in eval\\(l, envir\\) : ", "", as.character(l2))
     mess <- gsub("\\n", "", as.character(mess))
     messageVerbose(mess, verbose = verbose)
@@ -1564,6 +1582,22 @@ evalListElems <- function(l, envir, verbose = getOption("Require.verbose", 1L)) 
 
   } else {
     l <- l2
+  }
+  ## Report the final outcome to the diagnostic scope (if one is open). We push
+  ## once -- after recovery has had its chance -- so an entry where eval failed
+  ## but the element-wise retry produced a usable value is recorded as
+  ## `recovered = TRUE` rather than as an ERROR. The most common "no recovery"
+  ## shape, which is what motivated this (a pkgload::load_all() call failing on
+  ## a parse error in the target package), leaves `l` identical to
+  ## `setupDiagOrigL` and falls through as `recovered = FALSE`.
+  if (!is.null(setupDiagInitialError)) {
+    recovered <- !identical(l, setupDiagOrigL)
+    setupDiagRecord(expr = setupDiagOrigL,
+                    error = setupDiagInitialError,
+                    warnings = warns,
+                    recovered = recovered)
+  } else if (length(warns)) {
+    setupDiagRecord(expr = setupDiagOrigL, warnings = warns, recovered = TRUE)
   }
   l
 }
@@ -2590,13 +2624,23 @@ evalSUB <- function(val, valObjName, envir, envir2) {
 
   if (is(val2, "try-error")) {
     val2 <- errorMsgCleaning(val2, valOrig)
+    ## record once at the FINAL outcome so expected first-try failures that the
+    ## fallback ladder recovered from are not reported. See R/diagnostics.R.
+    setupDiagRecord(context = valObjName, expr = valOrig, error = val2,
+                    warnings = warns, recovered = FALSE)
     warning(val2, call. = FALSE)
     val2 <- valOrig
   } else {
     if (exists("val3", inherits = FALSE))
       if (is(val3, "try-error")) {
         val3 <- errorMsgCleaning(val3, valOrig)
+        setupDiagRecord(context = valObjName, expr = valOrig, error = val3,
+                        warnings = warns, recovered = TRUE)
         warning(val3)
+      } else if (length(warns)) {
+        ## eval succeeded but conditions fired along the way
+        setupDiagRecord(context = valObjName, expr = valOrig,
+                        warnings = warns, recovered = TRUE)
       }
   }
 

--- a/tests/testthat/test-diagnostics.R
+++ b/tests/testthat/test-diagnostics.R
@@ -1,0 +1,148 @@
+## Tests for the setupProject diagnostics infrastructure (R/diagnostics.R).
+##
+## These exercise the recorder/reporter directly with synthetic records, plus
+## the evalListElems / evalSUB instrumentation against a controlled scope.
+## They deliberately avoid spinning up a real setupProject() call (which is
+## heavy and depends on the network); the goal here is to lock the contract:
+##
+##   * a single end-of-call record per (context, expr, error) triple
+##   * recovered = TRUE is reported but not counted as "unrecovered"
+##   * strict mode stops AFTER the summary is emitted (so the user keeps it)
+##   * duplicates from the multi-layer try ladder collapse to one entry
+
+closeAllScopes <- function() {
+  while (!is.null(setupDiagCurrent())) setupDiagClose()
+}
+
+test_that("setupDiagOpen / Close maintain a clean stack", {
+  closeAllScopes()
+  expect_null(setupDiagCurrent())
+
+  s1 <- setupDiagOpen()
+  expect_identical(setupDiagCurrent(), s1)
+
+  s2 <- setupDiagOpen()  # nested
+  expect_identical(setupDiagCurrent(), s2)
+
+  setupDiagClose()
+  expect_identical(setupDiagCurrent(), s1)
+
+  setupDiagClose()
+  expect_null(setupDiagCurrent())
+
+  ## extra close is a no-op
+  expect_silent(setupDiagClose())
+  expect_null(setupDiagCurrent())
+})
+
+test_that("setupDiagRecord ignores calls when no scope is open", {
+  closeAllScopes()
+  expect_silent(setupDiagRecord(
+    context = "X", expr = quote(foo()), error = "bad", recovered = FALSE))
+  ## nothing was created
+  expect_null(setupDiagCurrent())
+})
+
+test_that("setupDiagRecord drops no-op records (no error, no warnings)", {
+  closeAllScopes()
+  scope <- setupDiagOpen()
+  on.exit(closeAllScopes())
+  setupDiagRecord(context = "X", expr = quote(foo()))
+  expect_length(scope$attempts, 0L)
+})
+
+test_that("setupDiagReport prints, dedupes, and respects strict mode", {
+  closeAllScopes()
+  scope <- setupDiagOpen()
+  on.exit(closeAllScopes())
+
+  ## three records, the 1st and 3rd identical -> one dedup
+  setupDiagRecord(context = "sideEffects",
+                  expr = quote(pkgload::load_all("~/GitHub/fireSenseUtils")),
+                  error = "Failed to load R/ELFs.R", recovered = FALSE)
+  setupDiagRecord(context = "modules",
+                  expr = quote(other()),
+                  error = "object x not found", recovered = TRUE)
+  setupDiagRecord(context = "sideEffects",
+                  expr = quote(pkgload::load_all("~/GitHub/fireSenseUtils")),
+                  error = "Failed to load R/ELFs.R", recovered = FALSE)
+
+  out <- capture.output(setupDiagReport(scope, strict = FALSE), type = "message")
+  joined <- paste(out, collapse = "\n")
+
+  ## header reflects 1 unrecovered + 1 recovered after dedup
+  expect_match(joined, "1 unrecovered, 1 recovered", fixed = TRUE)
+  ## the unrecovered entry is tagged ERROR with its context
+  expect_match(joined, "ERROR \\[sideEffects\\]")
+  ## the recovered entry is tagged "recovered"
+  expect_match(joined, "recovered \\[modules\\]")
+  ## load_all line is printed exactly once (dedup)
+  expect_equal(sum(grepl("pkgload::load_all", out, fixed = TRUE)), 1L)
+  ## the strict-mode hint is included
+  expect_match(joined, "SpaDES.project.strict", fixed = TRUE)
+
+  ## strict mode escalates -- but only AFTER printing (the user keeps the summary)
+  err <- tryCatch(setupDiagReport(scope, strict = TRUE), error = identity)
+  expect_s3_class(err, "simpleError")
+  expect_match(conditionMessage(err), "1 unrecovered error", fixed = TRUE)
+})
+
+test_that("setupDiagReport is a no-op when no errors or warnings were recorded", {
+  closeAllScopes()
+  scope <- setupDiagOpen()
+  on.exit(closeAllScopes())
+  expect_silent(setupDiagReport(scope))
+})
+
+test_that("evalListElems pushes a recovered=FALSE record for an unrecovered failure", {
+  closeAllScopes()
+  scope <- setupDiagOpen()
+  on.exit(closeAllScopes())
+
+  ## bad-code shape mirrors the real swallow: a single call that errors and
+  ## that evalListElems cannot recover element-wise (not a list(...) call)
+  env <- new.env()
+  out <- suppressMessages(
+    evalListElems(quote(stop("boom-from-evalListElems")), envir = env, verbose = 0)
+  )
+  ## evalListElems returns the unevaluated input when nothing recovered
+  expect_identical(out, quote(stop("boom-from-evalListElems")))
+  expect_length(scope$attempts, 1L)
+  rec <- scope$attempts[[1]]
+  expect_false(rec$recovered)
+  expect_match(rec$expr, "boom-from-evalListElems", fixed = TRUE)
+  expect_match(paste(rec$error, collapse = "\n"), "boom-from-evalListElems")
+})
+
+test_that("evalListElems records nothing when eval succeeds quietly", {
+  closeAllScopes()
+  scope <- setupDiagOpen()
+  on.exit(closeAllScopes())
+
+  env <- new.env()
+  out <- evalListElems(quote(1 + 1), envir = env, verbose = 0)
+  expect_equal(out, 2)
+  expect_length(scope$attempts, 0L)
+})
+
+test_that("evalSUB records the final-outcome failure (recovered = FALSE)", {
+  closeAllScopes()
+  scope <- setupDiagOpen()
+  on.exit(closeAllScopes())
+
+  env <- new.env()
+  ## evalSUB warns rather than stopping on full failure; suppressWarnings so the
+  ## test stays quiet. We just care that the diagnostic record landed.
+  suppressWarnings(
+    evalSUB(quote(stop("boom-from-evalSUB")),
+            valObjName = "sideEffects",
+            envir = env, envir2 = env)
+  )
+  errRecs <- Filter(function(r) length(r$error), scope$attempts)
+  expect_gte(length(errRecs), 1L)
+  expect_true(any(vapply(errRecs, function(r) !r$recovered, logical(1))))
+  expect_true(any(vapply(errRecs, function(r)
+    grepl("boom-from-evalSUB", paste(r$error, collapse = "\n")), logical(1))))
+  expect_true(any(vapply(errRecs, function(r) identical(r$context, "sideEffects"),
+                         logical(1))))
+})


### PR DESCRIPTION
## Summary
- setupProject's resolution layer (`evalSUB` + `evalListElems`) is intentionally tolerant — retries entries through several envs, falls back element-wise on block failures. The cost: a *real* failure (e.g. `pkgload::load_all()` failing on a parse error in the target package) gets demoted to a verbose-gated `message()` and the run continues with a half-loaded namespace, causing downstream symptoms (no source hyperlinks, errors in "trivial" code, `browser()` not hitting) that look like SpaDES bugs but trace back to the swallow here.
- Adds a per-`setupProject()` diagnostic scope (`R/diagnostics.R`). `evalSUB` and `evalListElems` push one record at the *final* outcome of their try-ladder, so expected first-try failures that a fallback recovered are silent. The report dedupes by `(context, expr, error)`, splits ERROR / recovered / warning-only, and prints once on.exit.
- `options(SpaDES.project.strict = TRUE)` escalates to a final `stop()` **after** the summary, so the diagnostic is always visible before the trace.

## Output shape
Synthetic reproduction of the `pkgload::load_all` parse-error scenario:

```
setupProject diagnostics: 2 unrecovered, 0 recovered, 0 warning-only
  - ERROR [sideEffects]: { ... fakeLoadAll(...) ... }
      Failed to load R/ELFs.R
      Caused by error: ! `call` must be a call or environment, not a symbol.
  - ERROR: fakeLoadAll("~/GitHub/fireSenseUtils")
      Failed to load R/ELFs.R
      Caused by error: ! `call` must be a call or environment, not a symbol.
  (run setupProject(...) with options(SpaDES.project.strict = TRUE) to stop on unrecovered errors)
```

Two entries by design — the block-level view from `evalSUB` plus the per-statement view from `evalListElems` (the latter is the actionable line). Collapsible to one entry by tweaking the dedup key if preferred.

## Test plan
- [x] New `tests/testthat/test-diagnostics.R` — 29 assertions, all pass: scope stack discipline, no-op when no scope is open, no-error+no-warning records dropped, dedup, strict mode prints-then-stops, and live tests through `evalListElems` and `evalSUB` confirming the recorded `recovered` flag matches the actual recovery outcome.
- [ ] Sanity-check against a real run that previously masked an error (the FireSenseTesting setup that started this thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)