### PR TITLE
tolerateFailure

### DIFF
--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -12,16 +12,15 @@
 ##
 ## This module adds a per-`setupProject()` diagnostic scope:
 ##   - `setupDiagOpen()` pushes a scope onto a stack
-##   - `evalSUB` / `evalListElems` push records onto the current scope, BUT
-##     only after they know the *final* outcome (so an expected first-try
-##     failure recovered by a fallback is not reported as an error)
-##   - `setupDiagReport()` summarises records at the end of setupProject
-##   - `options(SpaDES.project.strict = TRUE)` escalates the summary to a stop
-##
-## Recording the final outcome (rather than every internal try) is the trick
-## that avoids drowning the report in expected-fallback noise; the report still
-## dedupes by deparsed expression in case the same expression bubbles through
-## both evalSUB and evalListElems.
+##   - `evalSUB` / `evalListElems` push records onto the current scope when
+##     they end on a try-error -- and the *caller* deletes that record via
+##     `setupDiagClearMatching()` if it resolved the value via its own fallback
+##     (e.g. evalDots() substituting from defaultDots). What survives in the
+##     scope at the end is therefore exactly the failures the run continued
+##     past without resolving.
+##   - `setupDiagReport()` prints those as "tolerated errors" (plus any
+##     warnings collected along the way) at the end of setupProject.
+##   - `options(SpaDES.project.strict = TRUE)` escalates the summary to a stop.
 
 .spadesProjectDiag <- new.env(parent = emptyenv())
 .spadesProjectDiag$stack <- list()
@@ -49,19 +48,15 @@ setupDiagCurrent <- function() {
   if (length(s)) s[[length(s)]] else NULL
 }
 
-## Record one resolved attempt. Callers must only call this AFTER the final
-## outcome of their try-ladder is known -- so `recovered = TRUE` actually means
-## "the eval eventually succeeded" and `recovered = FALSE` means "all paths
-## failed; the value handed back was the unevaluated input."
+## Record one tolerated-error / warning attempt.
 ##
 ## - `context`   short tag (`"sideEffects"`, `"modules"`, ...); use NA if unknown
 ## - `expr`      the original (unevaluated) expression the caller was resolving
 ## - `error`     try-error or condition collected from the failing path; NULL if
 ##               the only thing of note was a warning
 ## - `warnings`  warning messages collected via withCallingHandlers
-## - `recovered` TRUE if a fallback path produced a usable value
 setupDiagRecord <- function(context = NA_character_, expr, error = NULL,
-                            warnings = NULL, recovered = FALSE) {
+                            warnings = NULL) {
   scope <- setupDiagCurrent()
   if (is.null(scope)) return(invisible())
   if (is.null(error) && !length(warnings)) return(invisible())  # nothing to report
@@ -74,10 +69,34 @@ setupDiagRecord <- function(context = NA_character_, expr, error = NULL,
     context = if (is.null(context)) NA_character_ else context,
     expr = exprStr,
     error = error,
-    warnings = if (length(warnings)) as.character(warnings) else NULL,
-    recovered = isTRUE(recovered)
+    warnings = if (length(warnings)) as.character(warnings) else NULL
   )
   invisible()
+}
+
+## Delete matching prior records. Use this from a caller that *did* eventually
+## resolve a value (e.g. evalDots() substituting a defaultDots fallback after
+## evalSUB failed): the prior record is removed entirely, so the run continues
+## without a spurious entry in the summary.
+##
+## Match by (context, expr-deparse). Returns invisibly the number of records
+## that were deleted.
+setupDiagClearMatching <- function(context, expr) {
+  scope <- setupDiagCurrent()
+  if (is.null(scope)) return(invisible(0L))
+  if (!length(scope$attempts)) return(invisible(0L))
+
+  exprStr <- tryCatch(paste(deparse(expr, width.cutoff = 500L), collapse = " "),
+                      error = function(e) "<unparseable>")
+  contextChr <- if (is.null(context) || is.na(context)) NA_character_ else context
+
+  keep <- vapply(scope$attempts, function(r) {
+    !(identical(r$expr, exprStr) &&
+        (is.na(contextChr) || identical(r$context, contextChr)))
+  }, logical(1))
+  n <- sum(!keep)
+  scope$attempts <- scope$attempts[keep]
+  invisible(n)
 }
 
 ## Truncate a one-line string for the summary header.
@@ -104,18 +123,17 @@ setupDiagReport <- function(scope = setupDiagCurrent(),
   keys <- vapply(atts, function(r)
     paste(r$context, r$expr,
           if (is.null(r$error)) "" else paste(r$error, collapse = "\n"),
-          sep = ""), character(1))
+          sep = ""), character(1))
   atts <- atts[!duplicated(keys)]
 
-  hard <- Filter(function(r) length(r$error) && !r$recovered, atts)
-  soft <- Filter(function(r) length(r$error) &&  r$recovered, atts)
+  errs  <- Filter(function(r) length(r$error), atts)
   wOnly <- Filter(function(r) is.null(r$error) && length(r$warnings), atts)
 
-  if (!length(hard) && !length(soft) && !length(wOnly)) return(invisible())
+  if (!length(errs) && !length(wOnly)) return(invisible())
 
-  header <- sprintf(
-    "setupProject diagnostics: %d unrecovered, %d recovered, %d warning-only",
-    length(hard), length(soft), length(wOnly))
+  header <- sprintf("setupProject diagnostics: %d tolerated error%s, %d warning-only",
+                    length(errs), if (length(errs) != 1L) "s" else "",
+                    length(wOnly))
   message(header)
 
   pretty <- function(rec, tag) {
@@ -129,15 +147,14 @@ setupDiagReport <- function(scope = setupDiagCurrent(),
         for (line in unlist(strsplit(w, "\n", fixed = TRUE)))
           if (nzchar(line)) message("      warning: ", line)
   }
-  for (r in hard)  pretty(r, "ERROR")
-  for (r in soft)  pretty(r, "recovered")
+  for (r in errs)  pretty(r, "tolerated error")
   for (r in wOnly) pretty(r, "warning")
 
-  if (length(hard))
-    message("  (run setupProject(...) with options(SpaDES.project.strict = TRUE) to stop on unrecovered errors)")
-  if (isTRUE(strict) && length(hard)) {
-    stop(sprintf("setupProject: %d unrecovered error(s) (see diagnostics above)",
-                 length(hard)),
+  if (length(errs))
+    message("  (run setupProject(...) with options(SpaDES.project.strict = TRUE) to stop on tolerated errors)")
+  if (isTRUE(strict) && length(errs)) {
+    stop(sprintf("setupProject: %d tolerated error%s (see diagnostics above)",
+                 length(errs), if (length(errs) != 1L) "s" else ""),
          call. = FALSE)
   }
   invisible()

--- a/R/setupProject.R
+++ b/R/setupProject.R
@@ -1583,21 +1583,17 @@ evalListElems <- function(l, envir, verbose = getOption("Require.verbose", 1L)) 
   } else {
     l <- l2
   }
-  ## Report the final outcome to the diagnostic scope (if one is open). We push
-  ## once -- after recovery has had its chance -- so an entry where eval failed
-  ## but the element-wise retry produced a usable value is recorded as
-  ## `recovered = TRUE` rather than as an ERROR. The most common "no recovery"
-  ## shape, which is what motivated this (a pkgload::load_all() call failing on
-  ## a parse error in the target package), leaves `l` identical to
-  ## `setupDiagOrigL` and falls through as `recovered = FALSE`.
-  if (!is.null(setupDiagInitialError)) {
-    recovered <- !identical(l, setupDiagOrigL)
+  ## Report the final outcome to the diagnostic scope (if one is open). Only
+  ## push when the element-wise retry did NOT change `l` -- if it changed,
+  ## recovery resolved the value and there's nothing tolerated to surface.
+  ## The case that motivated this (pkgload::load_all() failing on a parse
+  ## error) leaves `l` identical to `setupDiagOrigL` and gets recorded.
+  if (!is.null(setupDiagInitialError) && identical(l, setupDiagOrigL)) {
     setupDiagRecord(expr = setupDiagOrigL,
                     error = setupDiagInitialError,
-                    warnings = warns,
-                    recovered = recovered)
-  } else if (length(warns)) {
-    setupDiagRecord(expr = setupDiagOrigL, warnings = warns, recovered = TRUE)
+                    warnings = warns)
+  } else if (length(warns) && is.null(setupDiagInitialError)) {
+    setupDiagRecord(expr = setupDiagOrigL, warnings = warns)
   }
   l
 }
@@ -2624,23 +2620,21 @@ evalSUB <- function(val, valObjName, envir, envir2) {
 
   if (is(val2, "try-error")) {
     val2 <- errorMsgCleaning(val2, valOrig)
-    ## record once at the FINAL outcome so expected first-try failures that the
-    ## fallback ladder recovered from are not reported. See R/diagnostics.R.
+    ## record at the FINAL outcome. If the caller later resolves this via its
+    ## own fallback (e.g. evalDots substituting defaultDots), it should delete
+    ## this record via setupDiagClearMatching(). See R/diagnostics.R.
     setupDiagRecord(context = valObjName, expr = valOrig, error = val2,
-                    warnings = warns, recovered = FALSE)
+                    warnings = warns)
     warning(val2, call. = FALSE)
     val2 <- valOrig
   } else {
     if (exists("val3", inherits = FALSE))
       if (is(val3, "try-error")) {
         val3 <- errorMsgCleaning(val3, valOrig)
-        setupDiagRecord(context = valObjName, expr = valOrig, error = val3,
-                        warnings = warns, recovered = TRUE)
         warning(val3)
       } else if (length(warns)) {
         ## eval succeeded but conditions fired along the way
-        setupDiagRecord(context = valObjName, expr = valOrig,
-                        warnings = warns, recovered = TRUE)
+        setupDiagRecord(context = valObjName, expr = valOrig, warnings = warns)
       }
   }
 
@@ -3007,8 +3001,13 @@ evalDots <- function(dots, dotsSUB, defaultDots, envir = parent.frame(),
             if (identical(possVal, dotsSUB[[dd]])) {
               possVal2 <- evalSUB(defaultDots[[dd]], envir2 = envir, envir = callingEnv,
                                   valObjName = "defaultDots")
-              if (!is.null(possVal2))
+              if (!is.null(possVal2)) {
                 dots[[dd]] <- possVal2
+                ## defaultDots produced a usable value, so delete the earlier
+                ## evalSUB record -- the run continues with the right value and
+                ## there's nothing tolerated to surface. See R/diagnostics.R.
+                setupDiagClearMatching("defaultDots", dotsSUB[[dd]])
+              }
             }
           } else {
             dots[[dd]] <- possVal
@@ -3028,8 +3027,12 @@ evalDots <- function(dots, dotsSUB, defaultDots, envir = parent.frame(),
                 if (is.name(d)) {
                   d1 <- evalSUB(d, valObjName = nam, envir2 = envir, envir = callingEnv)
                   if (is(d1, "try-error")) {
-                    if (isTRUE(haveDefaults))
+                    if (isTRUE(haveDefaults)) {
                       d1 <- defaultDots[[nam]]
+                      ## defaultDots absorbed the failure; delete the evalSUB
+                      ## record so nothing tolerated lands in the summary.
+                      setupDiagClearMatching(nam, d)
+                    }
                     # else
                     #   d1 <- d
                   }

--- a/tests/testthat/test-diagnostics.R
+++ b/tests/testthat/test-diagnostics.R
@@ -1,12 +1,10 @@
 ## Tests for the setupProject diagnostics infrastructure (R/diagnostics.R).
 ##
-## These exercise the recorder/reporter directly with synthetic records, plus
-## the evalListElems / evalSUB instrumentation against a controlled scope.
-## They deliberately avoid spinning up a real setupProject() call (which is
-## heavy and depends on the network); the goal here is to lock the contract:
-##
+## Contract:
 ##   * a single end-of-call record per (context, expr, error) triple
-##   * recovered = TRUE is reported but not counted as "unrecovered"
+##   * when a caller resolves the value via its own fallback, the record is
+##     DELETED via setupDiagClearMatching() -- nothing tolerated to surface
+##   * the report distinguishes "tolerated error" from "warning-only" only
 ##   * strict mode stops AFTER the summary is emitted (so the user keeps it)
 ##   * duplicates from the multi-layer try ladder collapse to one entry
 
@@ -30,16 +28,14 @@ test_that("setupDiagOpen / Close maintain a clean stack", {
   setupDiagClose()
   expect_null(setupDiagCurrent())
 
-  ## extra close is a no-op
-  expect_silent(setupDiagClose())
+  expect_silent(setupDiagClose())  # extra close is a no-op
   expect_null(setupDiagCurrent())
 })
 
 test_that("setupDiagRecord ignores calls when no scope is open", {
   closeAllScopes()
   expect_silent(setupDiagRecord(
-    context = "X", expr = quote(foo()), error = "bad", recovered = FALSE))
-  ## nothing was created
+    context = "X", expr = quote(foo()), error = "bad"))
   expect_null(setupDiagCurrent())
 })
 
@@ -56,35 +52,34 @@ test_that("setupDiagReport prints, dedupes, and respects strict mode", {
   scope <- setupDiagOpen()
   on.exit(closeAllScopes())
 
-  ## three records, the 1st and 3rd identical -> one dedup
+  ## two records identical -> one after dedup
   setupDiagRecord(context = "sideEffects",
                   expr = quote(pkgload::load_all("~/GitHub/fireSenseUtils")),
-                  error = "Failed to load R/ELFs.R", recovered = FALSE)
-  setupDiagRecord(context = "modules",
+                  error = "Failed to load R/ELFs.R")
+  setupDiagRecord(context = "options",
                   expr = quote(other()),
-                  error = "object x not found", recovered = TRUE)
+                  error = "boom")
   setupDiagRecord(context = "sideEffects",
                   expr = quote(pkgload::load_all("~/GitHub/fireSenseUtils")),
-                  error = "Failed to load R/ELFs.R", recovered = FALSE)
+                  error = "Failed to load R/ELFs.R")
 
   out <- capture.output(setupDiagReport(scope, strict = FALSE), type = "message")
   joined <- paste(out, collapse = "\n")
 
-  ## header reflects 1 unrecovered + 1 recovered after dedup
-  expect_match(joined, "1 unrecovered, 1 recovered", fixed = TRUE)
-  ## the unrecovered entry is tagged ERROR with its context
-  expect_match(joined, "ERROR \\[sideEffects\\]")
-  ## the recovered entry is tagged "recovered"
-  expect_match(joined, "recovered \\[modules\\]")
+  ## header uses the "tolerated error" language
+  expect_match(joined, "2 tolerated errors", fixed = TRUE)
+  ## bullets are tagged "tolerated error", not "ERROR"/"recovered"
+  expect_match(joined, "tolerated error [sideEffects]", fixed = TRUE)
+  expect_no_match(joined, "recovered")
   ## load_all line is printed exactly once (dedup)
   expect_equal(sum(grepl("pkgload::load_all", out, fixed = TRUE)), 1L)
-  ## the strict-mode hint is included
-  expect_match(joined, "SpaDES.project.strict", fixed = TRUE)
+  ## strict-mode hint includes the new phrasing
+  expect_match(joined, "stop on tolerated errors", fixed = TRUE)
 
-  ## strict mode escalates -- but only AFTER printing (the user keeps the summary)
+  ## strict mode escalates after printing
   err <- tryCatch(setupDiagReport(scope, strict = TRUE), error = identity)
   expect_s3_class(err, "simpleError")
-  expect_match(conditionMessage(err), "1 unrecovered error", fixed = TRUE)
+  expect_match(conditionMessage(err), "tolerated error", fixed = TRUE)
 })
 
 test_that("setupDiagReport is a no-op when no errors or warnings were recorded", {
@@ -94,24 +89,40 @@ test_that("setupDiagReport is a no-op when no errors or warnings were recorded",
   expect_silent(setupDiagReport(scope))
 })
 
-test_that("evalListElems pushes a recovered=FALSE record for an unrecovered failure", {
+test_that("setupDiagClearMatching deletes matching records, leaves others", {
   closeAllScopes()
   scope <- setupDiagOpen()
   on.exit(closeAllScopes())
 
-  ## bad-code shape mirrors the real swallow: a single call that errors and
-  ## that evalListElems cannot recover element-wise (not a list(...) call)
+  setupDiagRecord(context = "defaultDots",
+                  expr = quote(unlist(.samplingRange)),
+                  error = "object '.samplingRange' not found")
+  setupDiagRecord(context = "sideEffects",
+                  expr = quote(pkgload::load_all("X")),
+                  error = "boom")
+
+  n <- setupDiagClearMatching("defaultDots", quote(unlist(.samplingRange)))
+  expect_equal(n, 1L)
+  expect_length(scope$attempts, 1L)
+  expect_identical(scope$attempts[[1]]$context, "sideEffects")  # the other one stayed
+
+  ## no-op when there's no match
+  expect_equal(setupDiagClearMatching("defaultDots", quote(nothing_here())), 0L)
+  expect_length(scope$attempts, 1L)
+})
+
+test_that("evalListElems pushes a record for an unrecovered failure", {
+  closeAllScopes()
+  scope <- setupDiagOpen()
+  on.exit(closeAllScopes())
+
   env <- new.env()
   out <- suppressMessages(
     evalListElems(quote(stop("boom-from-evalListElems")), envir = env, verbose = 0)
   )
-  ## evalListElems returns the unevaluated input when nothing recovered
   expect_identical(out, quote(stop("boom-from-evalListElems")))
   expect_length(scope$attempts, 1L)
-  rec <- scope$attempts[[1]]
-  expect_false(rec$recovered)
-  expect_match(rec$expr, "boom-from-evalListElems", fixed = TRUE)
-  expect_match(paste(rec$error, collapse = "\n"), "boom-from-evalListElems")
+  expect_match(scope$attempts[[1]]$expr, "boom-from-evalListElems", fixed = TRUE)
 })
 
 test_that("evalListElems records nothing when eval succeeds quietly", {
@@ -125,14 +136,12 @@ test_that("evalListElems records nothing when eval succeeds quietly", {
   expect_length(scope$attempts, 0L)
 })
 
-test_that("evalSUB records the final-outcome failure (recovered = FALSE)", {
+test_that("evalSUB records a tolerated-error record (no recovered flag)", {
   closeAllScopes()
   scope <- setupDiagOpen()
   on.exit(closeAllScopes())
 
   env <- new.env()
-  ## evalSUB warns rather than stopping on full failure; suppressWarnings so the
-  ## test stays quiet. We just care that the diagnostic record landed.
   suppressWarnings(
     evalSUB(quote(stop("boom-from-evalSUB")),
             valObjName = "sideEffects",
@@ -140,9 +149,69 @@ test_that("evalSUB records the final-outcome failure (recovered = FALSE)", {
   )
   errRecs <- Filter(function(r) length(r$error), scope$attempts)
   expect_gte(length(errRecs), 1L)
-  expect_true(any(vapply(errRecs, function(r) !r$recovered, logical(1))))
   expect_true(any(vapply(errRecs, function(r)
     grepl("boom-from-evalSUB", paste(r$error, collapse = "\n")), logical(1))))
   expect_true(any(vapply(errRecs, function(r) identical(r$context, "sideEffects"),
                          logical(1))))
+  ## records no longer carry a `recovered` field
+  expect_true(all(vapply(scope$attempts, function(r) is.null(r$recovered),
+                         logical(1))))
+})
+
+test_that(paste("evalDots: when defaultDots absorbs a failure, no record",
+                "survives -- regression test for the .samplingRange case"), {
+  closeAllScopes()
+  scope <- setupDiagOpen()
+  on.exit(closeAllScopes())
+
+  callingEnv <- new.env(parent = globalenv())
+  envirCur   <- new.env(parent = callingEnv)
+  dots <- list(.samplingRange = quote(unlist(.samplingRange)))
+  defaultDots <- list(.samplingRange = 1990:2020)
+
+  out <- suppressWarnings(
+    evalDots(dots = dots, dotsSUB = dots, defaultDots = defaultDots,
+             envir = envirCur, callingEnv = callingEnv)
+  )
+  expect_equal(out$.samplingRange, 1990:2020)
+  ## no .samplingRange entry survives in the diagnostic scope
+  expect_false(
+    any(vapply(scope$attempts, function(r)
+      grepl("unlist(.samplingRange)", r$expr, fixed = TRUE), logical(1))),
+    info = "defaultDots resolved the value; the prior record should be deleted"
+  )
+})
+
+test_that(paste("evalDots: with the real build_proxy shape that surfaced",
+                "the bug, no .samplingRange record survives"), {
+  closeAllScopes()
+  scope <- setupDiagOpen()
+  on.exit(closeAllScopes())
+
+  ## set up exactly as setupProject does: pass through a function that calls
+  ## capture_dots() + build_proxy(). When the dot's expression cannot be
+  ## eagerly forced (.samplingRange not found in the caller env), build_proxy
+  ## installs an active binding that returns the unevaluated expression. This
+  ## is the shape that produced the user-visible "object '.samplingRange'
+  ## not found" before the recovery clear was wired in.
+  fnNm <- function(...) {
+    dotsSUB <- as.list(substitute(list(...)))[-1L]
+    dotsAll <- capture_dots(...)
+    proxy <- build_proxy(cur = environment(), caller = parent.frame(),
+                         dots = dotsAll)
+    list(proxyExec = proxy$exec, dotsSUB = dotsSUB)
+  }
+  got <- fnNm(.samplingRange = unlist(.samplingRange))
+  defaultDots <- list(.samplingRange = 1990:2020)
+
+  out <- suppressWarnings(
+    evalDots(dots = got$dotsSUB, dotsSUB = got$dotsSUB, defaultDots = defaultDots,
+             envir = environment(), callingEnv = got$proxyExec)
+  )
+  expect_equal(out$.samplingRange, 1990:2020)
+  expect_false(
+    any(vapply(scope$attempts, function(r)
+      grepl("unlist(.samplingRange)", r$expr, fixed = TRUE), logical(1))),
+    info = "defaultDots resolved the value; the prior record should be deleted"
+  )
 })


### PR DESCRIPTION
## Summary
Follow-up to #101 (errorsWithDiagnostics). Suppresses spurious "tolerated error" entries for the case where `evalSUB()` fails to resolve an expression but `evalDots()` substitutes a `defaultDots` fallback — the run continues with the correct value, so the failure should not surface in the summary. Originally surfaced as e.g. `unlist(.samplingRange)` being reported as an ERROR even though `defaultDots = list(.samplingRange = 1990:2020, ...)` resolved it.

Also drops the `recovered` concept from the diagnostic API and rename "unrecovered" → "tolerated error" throughout.

## Mechanism
- New `setupDiagClearMatching(context, expr)` helper deletes records matching `(context, deparsed expr)`.
- `evalDots()` calls it at the two sites that substitute a `defaultDots` fallback after `evalSUB()` returned the unevaluated input.
- The diagnostic record/report no longer carries a `recovered` field; the summary has a single "tolerated error" bucket (plus "warning-only"). Strict mode stops on tolerated errors.

## Output shape after the change
```
setupProject diagnostics: 1 tolerated error, 0 warning-only
  - tolerated error [sideEffects]: pkgload::load_all("~/GitHub/fireSenseUtils")
      Failed to load R/ELFs.R
      Caused by error in `abort()`:
      ! `call` must be a call or environment, not a symbol.
  (run setupProject(...) with options(SpaDES.project.strict = TRUE) to stop on tolerated errors)
```

## Test plan
- [x] `tests/testthat/test-diagnostics.R` — 36 assertions, all pass: unit tests of the new clear helper, regression test using the real `build_proxy` active-binding shape that surfaced the bug, and confirmation that no `.samplingRange` record survives after `defaultDots` resolves it.
- [ ] Sanity-run against the FireSenseTesting workflow once #359 (SpaDES.core) is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)