### PR TITLE
fix(setupProject): evaluate each `...` argument exactly once

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ URL:
     https://spades-project.predictiveecology.org/,
     https://github.com/PredictiveEcology/SpaDES.project
 Date: 2026-05-22
-Version: 1.0.1.9341
+Version: 1.0.1.9342
 Authors@R: c(
     person("Eliot J B", "McIntire", email = "eliot.mcintire@nrcan-rncan.gc.ca",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6914-8316")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ URL:
     https://spades-project.predictiveecology.org/,
     https://github.com/PredictiveEcology/SpaDES.project
 Date: 2026-05-22
-Version: 1.0.1.9340
+Version: 1.0.1.9341
 Authors@R: c(
     person("Eliot J B", "McIntire", email = "eliot.mcintire@nrcan-rncan.gc.ca",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6914-8316")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -90,6 +90,7 @@ version 1.0.1
 
 ## Bug fixes
 
+* `setupProject()` now evaluates each `...` argument exactly once, in the environment that holds `defaultDots`. A side-effecting expression (e.g. `.studyAreaName = { ...; if (exists(".studyAreaName")) .studyAreaName else paste0("ELF", .ELFind) }`) was previously evaluated up to three times.
 * `plotSAs()` (which plots study areas) no longer fails when the raster used for matching has categorical (factor) layers: those layers are now drawn with a discrete colour scale instead of erroring with "Discrete value supplied to a continuous scale". It also now handles plotting a study area on its own (with no matching raster), which previously failed.
 * `setupProject()`: CRAN placeholder guard no longer errors with `subscript out of bounds` when `getOption("repos")` is an unnamed character vector or lacks a `CRAN` entry.
 * `tmuxRunNextWorker()`: workers no longer need the `reproducible` package to start.

--- a/NEWS.md
+++ b/NEWS.md
@@ -90,7 +90,7 @@ version 1.0.1
 
 ## Bug fixes
 
-* `setupProject()` now evaluates each `...` argument exactly once, in the environment that holds `defaultDots`. A side-effecting expression (e.g. `.studyAreaName = { ...; if (exists(".studyAreaName")) .studyAreaName else paste0("ELF", .ELFind) }`) was previously evaluated up to three times.
+* `setupProject()` now evaluates each `...` argument exactly once, sequentially in declaration order. Previously a `{ }` block or self-referential dot (e.g. `.studyAreaName = { ... }`, `.samplingRange = unlist(.samplingRange)`) could be evaluated 2-3 times, and complex `...` expressions were force-evaluated prematurely in the caller scope (running side effects such as downloads early). Caller-supplied values still take precedence over `defaultDots`. See the "Argument order (evaluation sequence)" section of `?setupProject`.
 * `plotSAs()` (which plots study areas) no longer fails when the raster used for matching has categorical (factor) layers: those layers are now drawn with a discrete colour scale instead of erroring with "Discrete value supplied to a continuous scale". It also now handles plotting a study area on its own (with no matching raster), which previously failed.
 * `setupProject()`: CRAN placeholder guard no longer errors with `subscript out of bounds` when `getOption("repos")` is an unnamed character vector or lacks a `CRAN` entry.
 * `tmuxRunNextWorker()`: workers no longer need the `reproducible` package to start.

--- a/R/setupProject.R
+++ b/R/setupProject.R
@@ -294,15 +294,29 @@ NULL
 #' )
 #' ````
 #'
-#' \subsection{Argument order}{
-#' Arguments that are *not* the named arguments (i.e., the ones passed in `...`)
-#' are evaluated in the order they are written. Subsequent arguments can use the
-#' previous arguments. If "dot" arguments are declared before the first
-#' standard arguments (the "formals") of the function, then they will be evaluated
-#' prior to the `formals`. If they are after a single standard argument (i.e., not
-#' necessarily after *all* the named arguments), then they will be evaluated after
-#' all standard arguments. The exception to this is `params`, which will be evaluated
-#' like the `...` arguments, i.e., in order.
+#' \subsection{Argument order (evaluation sequence)}{
+#' The evaluation rules are:
+#'
+#' * **Each `...` argument is evaluated once, in the order it is written.** The
+#'   formal/named arguments (`paths`, `modules`, `options`, `params`, `times`, ...)
+#'   are each evaluated *in their entirety as a block*. So if a user needs an object
+#'   to exist before, e.g., `paths` is evaluated, they should declare that argument
+#'   *before* `paths`.
+#' * **Because of this sequential evaluation, any argument written *above* another
+#'   is available to it**, exactly like a normal series of statements. A later
+#'   argument can refer to the resolved value of an earlier one by name.
+#' * **If a name is undefined when an argument is evaluated, `setupProject()` inserts
+#'   the matching `defaultDots` value and re-evaluates.** A value the caller *does*
+#'   supply always takes precedence over the `defaultDots` fallback. This is what
+#'   makes a pattern such as
+#'   `.samplingRange = unlist(.samplingRange)` (with `defaultDots = list(.samplingRange = 1990:2020)`)
+#'   resolve to the caller's value when one is supplied (e.g. a batch run that sets
+#'   `.samplingRange` before calling), and to the default otherwise.
+#'
+#' If "dot" arguments are declared before the first formal argument, they are
+#' evaluated before the formals; otherwise they are evaluated after the formals.
+#' The exception is `params`, which is evaluated like the `...` arguments, i.e., in
+#' order.
 #'
 #' }
 #'
@@ -2931,7 +2945,7 @@ messageWarnStop <- function(..., type = getOption("SpaDES.project.messageWarnSto
 
 
 evalDots <- function(dots, dotsSUB, defaultDots, envir = parent.frame(),
-                     callingEnv = sys.frame(-2)) {
+                     callingEnv = sys.frame(-2), dotsScope = FALSE) {
   if (missing(dots))
     dots <- dotsSUB
   else
@@ -2970,16 +2984,38 @@ evalDots <- function(dots, dotsSUB, defaultDots, envir = parent.frame(),
           possVal <- dotsSUB[[dd]]
           stStart <- Sys.time()
           if (!is.name(dotsSUB[[dd]])) {
-            # Evaluate in `envir` (which already holds the resolved `defaultDots`)
-            #   FIRST, falling back to `callingEnv` only if needed. `envir` has the
-            #   defaults but NOT the self-referential proxy active-binding for `dd`
-            #   itself, so a `{ }` block such as
-            #     .studyAreaName = if (exists(".studyAreaName")) .studyAreaName else paste0("ELF", .ELFind)
-            #   resolves correctly on a single pass. Evaluating in `callingEnv`
-            #   first instead re-runs the (possibly side-effecting) block a second
-            #   time, because `exists(dd)` there is spuriously TRUE.
+            # Sequential, single-pass evaluation of a `...` argument (dotsScope).
+            #   Evaluate the expression exactly once in `evalEnvDD`, which models the
+            #   intended scope:
+            #     * parent = the genuine caller (so caller-supplied values -- incl.
+            #       batch-spawn overrides like `.samplingRange = 2020:2030` -- win),
+            #     * overlaid with every already-resolved argument (`envir`), so
+            #       arguments declared *above* are available exactly like a normal
+            #       sequence of statements, EXCEPT the dot's own name,
+            #     * with the dot's own name bound to its `defaultDots` value only
+            #       when the caller did not supply it (undefined -> insert default).
+            #   This bypasses the proxy's self-referential active bindings (which
+            #   otherwise make `exists(<dot>)` spuriously TRUE and feed a call back
+            #   into itself). `envir2 = envir` remains a fallback for the rare
+            #   expression that references something reachable only there.
+            evalEnvDD <- callingEnv
+            if (isTRUE(dotsScope)) {
+              gcEnv <- parent.env(callingEnv)
+              evalEnvDD <- new.env(parent = gcEnv)
+              nmsCopy <- setdiff(ls(envir, all.names = TRUE), c(dd, "..."))
+              if (length(nmsCopy))
+                list2env(mget(nmsCopy, envir = envir, inherits = FALSE), envir = evalEnvDD)
+              if (dd %in% namsDD && !exists(dd, envir = gcEnv, inherits = TRUE)) {
+                ddDef <- tryCatch(
+                  evalSUB(defaultDots[[dd]], envir = envir, envir2 = callingEnv,
+                          valObjName = "defaultDots"),
+                  error = function(e) NULL)
+                if (!is.null(ddDef) && !is.call(ddDef) && !is.name(ddDef))
+                  assign(dd, ddDef, envir = evalEnvDD)
+              }
+            }
             possVal <- suppressWarnings(
-              evalSUB(dotsSUB[[dd]], envir = envir, envir2 = callingEnv, valObjName = "defaultDots")
+              evalSUB(dotsSUB[[dd]], envir = evalEnvDD, envir2 = envir, valObjName = "defaultDots")
             )
           }
           if (identical(possVal, dotsSUB[[dd]])) {
@@ -3654,7 +3690,7 @@ basename2 <- function (x) {
 evalDotsOuter <- function(dots, dotsSUB, defaultDots, envir = parent.frame(),
                           callingEnv = sys.frame(-2)) {
   dotsSUB <- evalDots(dots, dotsSUB, defaultDots, envir = envir,
-                      callingEnv = callingEnv)
+                      callingEnv = callingEnv, dotsScope = TRUE)
   dotsSUBreworked <- list()
   for (i in seq(dotsSUB)) {
     val <- try(eval(dotsSUB[[i]], envir = envir))
@@ -4998,13 +5034,13 @@ capture_dots <- function(...) {
   for (i in seq_along(exprs)) {
     # Need to keep vals[i] and use list( ... ) on RHS:
     #   otherwise if first element is NULL, it causes it to disappear
-    # Only eagerly force *simple* dots (a bare symbol or a literal). A complex
-    #   expression -- e.g. a `{ ... }` block or a function call with side effects --
-    #   must NOT be forced here: this snapshot happens in the caller env (which lacks
-    #   `defaultDots` and sibling-dot bindings), so it would both evaluate in the
-    #   wrong scope and run side effects an extra time. Left as NULL, build_proxy()
-    #   falls back to the unevaluated `expr`, which is then evaluated exactly once,
-    #   later, in the correct environment via evalDots()/evalSUB().
+    # Only eagerly force *simple* dots (a bare symbol or a literal). Forcing a
+    #   complex expression here -- a `{ }` block or a function call -- evaluates it
+    #   eagerly in the caller env (lacking defaultDots / sibling-dot bindings),
+    #   which (a) runs side effects (downloads, browser, print) prematurely and in
+    #   the wrong scope and (b) is then redone in evalDots() anyway. Left lazy,
+    #   build_proxy() keeps the unevaluated `expr` and it is evaluated once, later,
+    #   in the correct environment.
     ex <- exprs[[i]]
     if (is.symbol(ex) || is.atomic(ex)) {
       vals[i] <- list(tryCatch(

--- a/R/setupProject.R
+++ b/R/setupProject.R
@@ -2970,8 +2970,16 @@ evalDots <- function(dots, dotsSUB, defaultDots, envir = parent.frame(),
           possVal <- dotsSUB[[dd]]
           stStart <- Sys.time()
           if (!is.name(dotsSUB[[dd]])) {
+            # Evaluate in `envir` (which already holds the resolved `defaultDots`)
+            #   FIRST, falling back to `callingEnv` only if needed. `envir` has the
+            #   defaults but NOT the self-referential proxy active-binding for `dd`
+            #   itself, so a `{ }` block such as
+            #     .studyAreaName = if (exists(".studyAreaName")) .studyAreaName else paste0("ELF", .ELFind)
+            #   resolves correctly on a single pass. Evaluating in `callingEnv`
+            #   first instead re-runs the (possibly side-effecting) block a second
+            #   time, because `exists(dd)` there is spuriously TRUE.
             possVal <- suppressWarnings(
-              evalSUB(dotsSUB[[dd]], envir = callingEnv, envir2 = envir, valObjName = "defaultDots")
+              evalSUB(dotsSUB[[dd]], envir = envir, envir2 = callingEnv, valObjName = "defaultDots")
             )
           }
           if (identical(possVal, dotsSUB[[dd]])) {
@@ -4990,10 +4998,22 @@ capture_dots <- function(...) {
   for (i in seq_along(exprs)) {
     # Need to keep vals[i] and use list( ... ) on RHS:
     #   otherwise if first element is NULL, it causes it to disappear
-    vals[i] <- list(tryCatch(
-      ...elt(i),
-      error = function(e) NULL
-    ))
+    # Only eagerly force *simple* dots (a bare symbol or a literal). A complex
+    #   expression -- e.g. a `{ ... }` block or a function call with side effects --
+    #   must NOT be forced here: this snapshot happens in the caller env (which lacks
+    #   `defaultDots` and sibling-dot bindings), so it would both evaluate in the
+    #   wrong scope and run side effects an extra time. Left as NULL, build_proxy()
+    #   falls back to the unevaluated `expr`, which is then evaluated exactly once,
+    #   later, in the correct environment via evalDots()/evalSUB().
+    ex <- exprs[[i]]
+    if (is.symbol(ex) || is.atomic(ex)) {
+      vals[i] <- list(tryCatch(
+        ...elt(i),
+        error = function(e) NULL
+      ))
+    } else {
+      vals[i] <- list(NULL)
+    }
   }
 
   list(exprs = exprs, vals = vals)


### PR DESCRIPTION
## Problem

`...` arguments to `setupProject()` were not evaluated according to the intended sequential, single-pass model:

- A side-effecting or self-referential `...` argument could be evaluated **2–3 times**, e.g.
  - `.studyAreaName = { browser(); ifelse(exists(".studyAreaName"), .studyAreaName, paste0("ELF", .ELFind)) }`
  - `.samplingRange = unlist(.samplingRange)` (with a `defaultDots` fallback)
- Complex `...` expressions were **force-evaluated prematurely in the caller scope** by `capture_dots()`, running side effects (downloads, `browser()`, `print()`) early and in the wrong environment — e.g. a trailing `studyArea`/`studyAreaLarge` arg downloading before setup was ready.

## Intended model (now documented)

Per the new *"Argument order (evaluation sequence)"* roxygen subsection:

1. Each `...` argument is evaluated **once, in declaration order**; the formal/named args (`paths`, `modules`, …) are each evaluated as a block.
2. Any argument written **above** another is available to it, like a normal series of statements.
3. If a name is **undefined** when an argument is evaluated, `setupProject()` inserts the matching `defaultDots` value and re-evaluates. Caller-supplied values take precedence.

## Fix (`R/setupProject.R`)

- **`capture_dots()`**: only eagerly force *simple* dots (a bare symbol or a literal). `{ }` blocks and function calls stay lazy and are evaluated once, later, in the correct environment.
- **`evalDots()`**: new gated `dotsScope` path (used only for `...` via `evalDotsOuter()`) evaluates each dot exactly once, sequentially, in an environment that is the **genuine caller** overlaid with the **already-resolved arguments**, with the dot's own name bound to its `defaultDots` value only when the caller did not supply it. This bypasses the proxy's self-referential active bindings that made `exists(<dot>)` spuriously TRUE and could feed a call back into itself (the infinite loop on `unlist(.samplingRange)`-style dots).

## Verification

Each dot evaluated **once**, in declaration order, across:

| Case | evals | result |
|---|---|---|
| `.studyAreaName={…}`, caller `.ELFind=1` | 1 | `ELF1` |
| default `.ELFind` | 1 | `ELF4.3` |
| caller `.samplingRange=2020:2030` (batch override) | 1 | `2020..2030` |
| caller `.studyAreaName="MyArea"` | 1 | `MyArea` |
| early-dots path (many dots before `defaultDots`) | 1 each | correct |

Full `test-setupProject.R` suite passes (18/18, `NOT_CRAN=true`); `test-diagnostics.R` passes.

> Note: history includes an earlier commit whose approach stalled on self-referential `defaultDots` dots and reordered evaluation; the final commit supersedes it. Net diff vs `development` is the corrected implementation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)