### PR TITLE
fix(plot): exclude dot-prefixed studyArea names in makeListToPlot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ URL:
     https://spades-project.predictiveecology.org/,
     https://github.com/PredictiveEcology/SpaDES.project
 Date: 2026-06-14
-Version: 1.0.1.9363
+Version: 1.0.1.9364
 Authors@R: c(
     person("Eliot J B", "McIntire", email = "eliot.mcintire@nrcan-rncan.gc.ca",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6914-8316")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -102,6 +102,7 @@ version 1.0.1
 
 ## Bug fixes
 
+* `plotSAs()`/`plotSAsLeaflet()` no longer pick up dot-prefixed study-area objects (e.g. `sim.studyArea`) as layers to plot.
 * `setupProject()`: the `useGit`, `standAlone`, `updateRprofile`, `setLinuxBinaryRepo`, and `overwrite` arguments now fall back to their documented `getOption("SpaDES.project.*", <default>)` value instead of `NULL` when the option is unset, matching the inner `setup*` functions and `spadesProjectOptions()` (`setLinuxBinaryRepo` now defaults to running on Linux).
 * `spadesProjectOptions()`: help page now documents the default and meaning of every option it returns, and each `setupProject()` argument's `@param` states its default explicitly.
 

--- a/R/studyAreaPlotting.R
+++ b/R/studyAreaPlotting.R
@@ -430,7 +430,7 @@ makeListToPlot <- function(ll, include, exclude, ...) {
   if (length(dots))
     ll <- appendDotsToLL(ll, dots)
 
-  sasNames <- grep(names(ll), pattern = "studyArea", value = TRUE)
+  sasNames <- grep(names(ll), pattern = "^[^.]*studyArea", value = TRUE)
   rtmsNames <- grep(names(ll), pattern = "rasterToMatch", value = TRUE)
 
   RastClasses <- "SpatRaster"

--- a/tests/testthat/test-studyAreaPlotting.R
+++ b/tests/testthat/test-studyAreaPlotting.R
@@ -39,3 +39,22 @@ test_that(".leafletGeoTiffPath: unique paths per raster name within one chunk", 
     expect_false(identical(p1, p2))
   })
 })
+
+test_that("makeListToPlot: studyArea selection excludes dot-prefixed names", {
+  skip_if_not_installed("sf")
+
+  mkPoly <- function() {
+    m <- matrix(c(0, 0, 1, 0, 1, 1, 0, 1, 0, 0), ncol = 2, byrow = TRUE)
+    sf::st_sfc(sf::st_polygon(list(m)), crs = 4326)
+  }
+
+  ## names with a `.` before "studyArea" (e.g. `sim.studyArea`) are the "dot"
+  ## versions that must NOT be picked up as study areas to plot
+  ll <- list(studyArea = mkPoly(), studyAreaLarge = mkPoly(),
+             sim.studyArea = mkPoly())
+
+  out <- SpaDES.project:::makeListToPlot(ll, include = FALSE)
+
+  expect_setequal(out$sasNames, c("studyArea", "studyAreaLarge"))
+  expect_false("sim.studyArea" %in% out$sasNames)
+})


### PR DESCRIPTION
## Summary
`makeListToPlot()` selected study-area layers by grepping `names(ll)` for `"studyArea"`, which also matched dot-prefixed helper objects such as `sim.studyArea`. These got plotted as if they were top-level study areas.

The grep pattern is now anchored to `"^[^.]*studyArea"`, so a `.` anywhere before `studyArea` (the "dot" versions) excludes the name, while `studyArea`, `studyAreaLarge`, etc. are still selected.

## Test
Adds a focused test in `test-studyAreaPlotting.R` that runs `makeListToPlot()` over a list containing `studyArea`, `studyAreaLarge`, and `sim.studyArea`, asserting the first two are selected and `sim.studyArea` is excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)